### PR TITLE
Table column alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Code Structure
 --------------
 
 | File           | Content                                            |
-| --------------:|:---------------------------------------------------|
+|----------------|----------------------------------------------------|
 | dist/          | contains a browser-ready build of the parser       |
 | src/jison/     | contains the jison parser files.                   |
 | src/lib/       | external libraries that the parser depends on.     |


### PR DESCRIPTION
Left-aligned first column of code structure table because it's easier to read when the directories line up on the left.

@emord 