### PR TITLE
Bump pbkdf2 to 3.1.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,7 +1344,7 @@ path-platform@~0.11.15:
   version "0.11.15"
   resolved "https://registry.yarnpkg.com/path-platform/-/path-platform-0.11.15.tgz#e864217f74c36850f0852b78dc7bf7d4a5721bf2"
 
-pbkdf2@^3.0.3:
+pbkdf2@^3.1.3:
   version "3.0.12"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.12.tgz#be36785c5067ea48d806ff923288c5f750b6b8a2"
   dependencies:


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-17970

[Changelog](https://github.com/browserify/pbkdf2/blob/master/CHANGELOG.md)

This is a minor version upgrade and I don't see any breaking changes in the changelog. This package is ultimately a sub dependency of browserify (my understanding) which is used to bundle javascript. We use the bundled js in tests so that is a good sign that tests are passing.