### PR TITLE
bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-xpath",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "An xpath parser",
   "authors": [
     "Dimagi <dev@dimagi.com>"


### PR DESCRIPTION
After updating dependencies in https://github.com/dimagi/js-xpath/pull/53, this PR bumps js-xpath from 0.0.9 to 0.0.10